### PR TITLE
Sort getFormElement results by display_name, object_name

### DIFF
--- a/library/Director/DataType/DataTypeDirectorObject.php
+++ b/library/Director/DataType/DataTypeDirectorObject.php
@@ -30,7 +30,8 @@ class DataTypeDirectorObject extends DataTypeHook
         } else {
             $query->where('object_type = ?', 'object');
         }
-
+        $query->order('display_name, object_name');
+        
         $enum = $db->fetchPairs($query);
 
 


### PR DESCRIPTION
Fix for issue #840

Sorts result of DataTypeDirectorObject by display_name, object_name for easier selection in the frontend